### PR TITLE
Make CsvReader and CsvWriter closeable

### DIFF
--- a/src/main/php/text/csv/CsvReader.class.php
+++ b/src/main/php/text/csv/CsvReader.class.php
@@ -1,7 +1,7 @@
 <?php namespace text\csv;
 
 use io\streams\TextReader;
-use lang\{FormatException, IllegalStateException, Throwable};
+use lang\{FormatException, IllegalStateException, Closeable, Throwable};
 
 /**
  * Abstract base class
@@ -10,7 +10,7 @@ use lang\{FormatException, IllegalStateException, Throwable};
  * @see   xp://text.csv.CsvObjectReader
  * @see   xp://text.csv.CsvBeanReader
  */
-abstract class CsvReader extends AbstractCsvProcessor {
+abstract class CsvReader extends AbstractCsvProcessor implements Closeable {
   const WHITESPACE= " \t";
 
   protected $reader= null;
@@ -154,4 +154,9 @@ abstract class CsvReader extends AbstractCsvProcessor {
 
   /** @return text.csv.Lines */
   public function lines() { return new Lines($this); }
+
+  /** @return void */
+  public function close() {
+    $this->reader->close();
+  }
 }

--- a/src/main/php/text/csv/CsvWriter.class.php
+++ b/src/main/php/text/csv/CsvWriter.class.php
@@ -1,7 +1,7 @@
 <?php namespace text\csv;
 
 use io\streams\TextWriter;
-use lang\{FormatException, IllegalStateException, Throwable};
+use lang\{FormatException, IllegalStateException, Throwable, Closeable};
 
 /**
  * Abstract base class
@@ -10,7 +10,7 @@ use lang\{FormatException, IllegalStateException, Throwable};
  * @see   xp://text.csv.CsvObjectWriter
  * @see   xp://text.csv.CsvBeanWriter
  */
-abstract class CsvWriter extends \text\csv\AbstractCsvProcessor {
+abstract class CsvWriter extends AbstractCsvProcessor implements Closeable {
   protected $writer= null;
   protected $format= null;
   protected $line= 0;
@@ -73,5 +73,10 @@ abstract class CsvWriter extends \text\csv\AbstractCsvProcessor {
     }
     $this->line++;
     $this->writer->writeLine(substr($line, 0, -1));
+  }
+
+  /** @return void */
+  public function close() {
+    $this->writer->close();
   }
 }

--- a/src/test/php/text/csv/unittest/CsvBeanReaderTest.class.php
+++ b/src/test/php/text/csv/unittest/CsvBeanReaderTest.class.php
@@ -3,29 +3,24 @@
 use io\streams\{MemoryInputStream, TextReader};
 use lang\XPClass;
 use text\csv\CsvBeanReader;
-use unittest\Test;
+use unittest\{Test, TestCase};
 
-/**
- * TestCase
- *
- * @see      xp://text.csv.CsvBreanReader
- */
-class CsvBeanReaderTest extends \unittest\TestCase {
+class CsvBeanReaderTest extends CsvReaderTest {
 
   /**
-   * Creates a new object reader
+   * Creates a new CSV reader fixture
    *
-   * @param   string str
-   * @param   lang.XPClass class
-   * @return  text.csv.CsvBeanReader
+   * @param  io.streams.InputStream $stream
+   * @param  text.csv.CsvFormat $format
+   * @return text.csv.CsvBeanReader
    */
-  protected function newReader($str, XPClass $class) {
-    return new CsvBeanReader(new TextReader(new MemoryInputStream($str)), $class);
+  protected function newFixture($stream, $format= null) {
+    return new CsvBeanReader(new TextReader($stream), new XPClass(Person::class), $format);
   }
 
   #[Test]
-  public function readPerson() {
-    $in= $this->newReader('1549;Timm;friebe@example.com', XPClass::forName('text.csv.unittest.Person'));
+  public function read_person() {
+    $in= $this->newFixture(new MemoryInputStream('1549;Timm;friebe@example.com'));
     $this->assertEquals(
       new Person('1549', 'Timm', 'friebe@example.com'), 
       $in->read(['id', 'name', 'email'])
@@ -33,8 +28,8 @@ class CsvBeanReaderTest extends \unittest\TestCase {
   }
 
   #[Test]
-  public function readPersonReSorted() {
-    $in= $this->newReader('friebe@example.com;1549;Timm', XPClass::forName('text.csv.unittest.Person'));
+  public function read_person_resorted() {
+    $in= $this->newFixture(new MemoryInputStream('friebe@example.com;1549;Timm'));
     $this->assertEquals(
       new Person('1549', 'Timm', 'friebe@example.com'), 
       $in->read(['email', 'id', 'name'])
@@ -42,8 +37,8 @@ class CsvBeanReaderTest extends \unittest\TestCase {
   }
 
   #[Test]
-  public function readPersonCompletely() {
-    $in= $this->newReader('1549;Timm;friebe@example.com', XPClass::forName('text.csv.unittest.Person'));
+  public function read_person_completely() {
+    $in= $this->newFixture(new MemoryInputStream('1549;Timm;friebe@example.com'));
     $this->assertEquals(
       new Person('1549', 'Timm', 'friebe@example.com'), 
       $in->read()
@@ -51,8 +46,8 @@ class CsvBeanReaderTest extends \unittest\TestCase {
   }
 
   #[Test]
-  public function readPersonPartially() {
-    $in= $this->newReader('1549;Timm;friebe@example.com', XPClass::forName('text.csv.unittest.Person'));
+  public function read_person_partially() {
+    $in= $this->newFixture(new MemoryInputStream('1549;Timm;friebe@example.com'));
     $this->assertEquals(
       new Person('1549', 'Timm', ''), 
       $in->read(['id', 'name'])
@@ -60,8 +55,8 @@ class CsvBeanReaderTest extends \unittest\TestCase {
   }
 
   #[Test]
-  public function readEmpty() {
-    $in= $this->newReader('', XPClass::forName('text.csv.unittest.Person'));
+  public function read_empty() {
+    $in= $this->newFixture(new MemoryInputStream(''));
     $this->assertNull($in->read(['id', 'name', 'email']));
   }
 }

--- a/src/test/php/text/csv/unittest/CsvBeanWriterTest.class.php
+++ b/src/test/php/text/csv/unittest/CsvBeanWriterTest.class.php
@@ -2,42 +2,42 @@
 
 use io\streams\{MemoryOutputStream, TextWriter};
 use text\csv\{CsvBeanWriter, CsvFormat};
-use unittest\{Test, TestCase};
+use unittest\Test;
 
-/**
- * TestCase
- *
- * @see      xp://text.csv.CsvBeanWriter
- */
-class CsvBeanWriterTest extends TestCase {
-  protected $out= null;
+class CsvBeanWriterTest extends CsvWriterTest {
 
   /**
-   * Creates a new bean writer
+   * Creates a new CSV writer fixture
    *
-   * @param   text.csv.CsvFormat format
-   * @return  text.csv.CsvBeanWriter
+   * @param  io.streams.OutputStream $stream
+   * @param  text.csv.CsvFormat $format
+   * @return text.csv.CsvWriter
    */
-  protected function newWriter(CsvFormat $format= null) {
-    $this->out= new MemoryOutputStream();
-    return new CsvBeanWriter(new TextWriter($this->out), $format);
+  protected function newFixture($stream, $format= null) {
+    return new CsvBeanWriter(new TextWriter($stream), $format);
   }
 
   #[Test]
   public function writePerson() {
-    $this->newWriter()->write(new Person(1549, 'Timm', 'friebe@example.com'));
-    $this->assertEquals("1549;Timm;friebe@example.com\n", $this->out->bytes());
+    $out= new MemoryOutputStream();
+    $this->newFixture($out)->write(new Person(1549, 'Timm', 'friebe@example.com'));
+
+    $this->assertEquals("1549;Timm;friebe@example.com\n", $out->bytes());
   }
 
   #[Test]
   public function writePersonReSorted() {
-    $this->newWriter()->write(new Person(1549, 'Timm', 'friebe@example.com'), ['email', 'id', 'name']);
-    $this->assertEquals("friebe@example.com;1549;Timm\n", $this->out->bytes());
+    $out= new MemoryOutputStream();
+    $this->newFixture($out)->write(new Person(1549, 'Timm', 'friebe@example.com'), ['email', 'id', 'name']);
+
+    $this->assertEquals("friebe@example.com;1549;Timm\n", $out->bytes());
   }
 
   #[Test]
   public function writePersonPartially() {
-    $this->newWriter()->write(new Person(1549, 'Timm', 'friebe@example.com'), ['id', 'name']);
-    $this->assertEquals("1549;Timm\n", $this->out->bytes());
+    $out= new MemoryOutputStream();
+    $this->newFixture($out)->write(new Person(1549, 'Timm', 'friebe@example.com'), ['id', 'name']);
+
+    $this->assertEquals("1549;Timm\n", $out->bytes());
   }
 }

--- a/src/test/php/text/csv/unittest/CsvListReaderTest.class.php
+++ b/src/test/php/text/csv/unittest/CsvListReaderTest.class.php
@@ -3,208 +3,202 @@
 use io\streams\{MemoryInputStream, TextReader};
 use lang\{FormatException, IllegalStateException};
 use text\csv\{CsvFormat, CsvListReader};
-use unittest\{Expect, Ignore, Test, TestCase};
+use unittest\{Expect, Ignore, Test};
 
-/**
- * TestCase
- *
- * @see   xp://text.csv.CsvListReader
- * @see   http://en.wikipedia.org/wiki/Comma-separated_values
- */
-class CsvListReaderTest extends TestCase {
+class CsvListReaderTest extends CsvReaderTest {
 
   /**
-   * Ctreates a new list reader
+   * Creates a new CSV reader fixture
    *
-   * @param   string str
-   * @param   text.csv.CsvFormat format
-   * @return  text.csv.CsvListReader
+   * @param  io.streams.InputStream $stream
+   * @param  text.csv.CsvFormat $format
+   * @return text.csv.CsvReader
    */
-  protected function newReader($str, CsvFormat $format= null) {
-    return new CsvListReader(new TextReader(new MemoryInputStream($str)), $format);
+  protected function newFixture($stream, $format= null) {
+    return new CsvListReader(new TextReader($stream), $format);
   }
 
   #[Test]
-  public function readLine() {
-    $in= $this->newReader('Timm;Karlsruhe;76137');
+  public function read_line() {
+    $in= $this->newFixture(new MemoryInputStream('Timm;Karlsruhe;76137'));
     $this->assertEquals(['Timm', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function readLineDelimitedByCommas() {
-    $in= $this->newReader('Timm,Karlsruhe,76137', (new CsvFormat())->withDelimiter(','));
+  public function read_line_delimited_by_commas() {
+    $in= $this->newFixture(new MemoryInputStream('Timm,Karlsruhe,76137'), (new CsvFormat())->withDelimiter(','));
     $this->assertEquals(['Timm', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function readLineDelimitedByPipes() {
-    $in= $this->newReader('Timm|Karlsruhe|76137', (new CsvFormat())->withDelimiter('|'));
+  public function read_line_delimited_by_pipes() {
+    $in= $this->newFixture(new MemoryInputStream('Timm|Karlsruhe|76137'), (new CsvFormat())->withDelimiter('|'));
     $this->assertEquals(['Timm', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function readEmpty() {
-    $in= $this->newReader('');
+  public function read_empty() {
+    $in= $this->newFixture(new MemoryInputStream(''));
     $this->assertNull($in->read());
   }
 
   #[Test]
-  public function readMultipleLines() {
-    $in= $this->newReader('Timm;Karlsruhe;76137'."\n".'Alex;Karlsruhe;76131');
+  public function read_multiple_lines() {
+    $in= $this->newFixture(new MemoryInputStream('Timm;Karlsruhe;76137'."\n".'Alex;Karlsruhe;76131'));
     $this->assertEquals(['Timm', 'Karlsruhe', '76137'], $in->read());
     $this->assertEquals(['Alex', 'Karlsruhe', '76131'], $in->read());
   }
 
   #[Test]
-  public function getHeaders() {
-    $in= $this->newReader('name;city;zip'."\n".'Alex;Karlsruhe;76131');
+  public function get_headers() {
+    $in= $this->newFixture(new MemoryInputStream('name;city;zip'."\n".'Alex;Karlsruhe;76131'));
     $this->assertEquals(['name', 'city', 'zip'], $in->getHeaders());
     $this->assertEquals(['Alex', 'Karlsruhe', '76131'], $in->read());
   }
 
   #[Test, Expect(IllegalStateException::class)]
-  public function cannotGetHeadersAfterReading() {
-    $in= $this->newReader('Timm;Karlsruhe;76137');
+  public function cannot_get_headers_after_reading() {
+    $in= $this->newFixture(new MemoryInputStream('Timm;Karlsruhe;76137'));
     $in->read();
     $in->getHeaders();
   }
 
   #[Test]
-  public function leadingWhitespace() {
-    $in= $this->newReader(' Timm;Karlsruhe;76137');
+  public function leading_whitespace() {
+    $in= $this->newFixture(new MemoryInputStream(' Timm;Karlsruhe;76137'));
     $this->assertEquals(['Timm', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function leadingTab() {
-    $in= $this->newReader("\tTimm;Karlsruhe;76137");
+  public function leading_tab() {
+    $in= $this->newFixture(new MemoryInputStream("\tTimm;Karlsruhe;76137"));
     $this->assertEquals(['Timm', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function leadingTabAndWhiteSpace() {
-    $in= $this->newReader("\t  Timm;Karlsruhe;76137");
+  public function leading_tab_and_whitespace() {
+    $in= $this->newFixture(new MemoryInputStream("\t  Timm;Karlsruhe;76137"));
     $this->assertEquals(['Timm', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function leadingWhitespaces() {
-    $in= $this->newReader('Timm;    Karlsruhe;    76137');
+  public function leading_whitespaces() {
+    $in= $this->newFixture(new MemoryInputStream('Timm;    Karlsruhe;    76137'));
     $this->assertEquals(['Timm', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function leadingTabs() {
-    $in= $this->newReader("Timm;\tKarlsruhe;\t76137");
+  public function leading_tabs() {
+    $in= $this->newFixture(new MemoryInputStream("Timm;\tKarlsruhe;\t76137"));
     $this->assertEquals(['Timm', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
   public function trailingWhitespace() {
-    $in= $this->newReader('Timm ;Karlsruhe;76137');
+    $in= $this->newFixture(new MemoryInputStream('Timm ;Karlsruhe;76137'));
     $this->assertEquals(['Timm', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function trailingTab() {
-    $in= $this->newReader("Timm\t;Karlsruhe;76137");
+  public function trailing_tab() {
+    $in= $this->newFixture(new MemoryInputStream("Timm\t;Karlsruhe;76137"));
     $this->assertEquals(['Timm', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function surroundingWhitespace() {
-    $in= $this->newReader('Timm   ;   Karlsruhe   ;   76137');
+  public function surrounding_whitespace() {
+    $in= $this->newFixture(new MemoryInputStream('Timm   ;   Karlsruhe   ;   76137'));
     $this->assertEquals(['Timm', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function whiteSpaceAndEmpty() {
-    $in= $this->newReader('       ;   Karlsruhe   ;   76137');
+  public function whitespace_and_empty() {
+    $in= $this->newFixture(new MemoryInputStream('       ;   Karlsruhe   ;   76137'));
     $this->assertEquals(['', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function readQuotedValue() {
-    $in= $this->newReader('"Timm";Karlsruhe;76137');
+  public function read_quoted_value() {
+    $in= $this->newFixture(new MemoryInputStream('"Timm";Karlsruhe;76137'));
     $this->assertEquals(['Timm', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function readQuotedValueWithSurroundingWhitespace() {
-    $in= $this->newReader('   "Timm"    ;Karlsruhe;76137');
+  public function read_quoted_value_with_surrounding_whitespace() {
+    $in= $this->newFixture(new MemoryInputStream('   "Timm"    ;Karlsruhe;76137'));
     $this->assertEquals(['Timm', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function readQuotedValueIncludingWhitespace() {
-    $in= $this->newReader('"   Timm    ";Karlsruhe;76137');
+  public function read_quoted_value_including_whitespace() {
+    $in= $this->newFixture(new MemoryInputStream('"   Timm    ";Karlsruhe;76137'));
     $this->assertEquals(['   Timm    ', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function readQuotedValues() {
-    $in= $this->newReader('"Timm";"Karlsruhe";"76137"');
+  public function read_quoted_values() {
+    $in= $this->newFixture(new MemoryInputStream('"Timm";"Karlsruhe";"76137"'));
     $this->assertEquals(['Timm', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function readQuotedWithSingleQuotes() {
-    $in= $this->newReader("Timm;'Karlsruhe';76137", (new CsvFormat())->withQuote("'"));
+  public function read_quoted_with_single_quotes() {
+    $in= $this->newFixture(new MemoryInputStream("Timm;'Karlsruhe';76137"), (new CsvFormat())->withQuote("'"));
     $this->assertEquals(['Timm', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function readQuotedValueWithSeparator() {
-    $in= $this->newReader('"Friebe;Timm";Karlsruhe;76137');
+  public function read_quoted_value_with_separator() {
+    $in= $this->newFixture(new MemoryInputStream('"Friebe;Timm";Karlsruhe;76137'));
     $this->assertEquals(['Friebe;Timm', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function readQuotedValueWithSeparatorInMiddle() {
-    $in= $this->newReader('Timm;"Karlsruhe;Germany";76137');
+  public function read_quoted_value_with_separator_in_middle() {
+    $in= $this->newFixture(new MemoryInputStream('Timm;"Karlsruhe;Germany";76137'));
     $this->assertEquals(['Timm', 'Karlsruhe;Germany', '76137'], $in->read());
   }
 
   #[Test]
-  public function readQuotedValueWithSeparatorAtEnd() {
-    $in= $this->newReader('Timm;Karlsruhe;"76131;76135;76137"');
+  public function read_quoted_value_with_separator_at_end() {
+    $in= $this->newFixture(new MemoryInputStream('Timm;Karlsruhe;"76131;76135;76137"'));
     $this->assertEquals(['Timm', 'Karlsruhe', '76131;76135;76137'], $in->read());
   }
 
   #[Test]
-  public function readQuotedValueWithQuotes() {
-    $in= $this->newReader('"""Hello""";Karlsruhe;76137');
+  public function read_quoted_value_with_quotes() {
+    $in= $this->newFixture(new MemoryInputStream('"""Hello""";Karlsruhe;76137'));
     $this->assertEquals(['"Hello"', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function readEmptyQuotedValue() {
-    $in= $this->newReader('"";Karlsruhe;76137');
+  public function read_empty_quoted_value() {
+    $in= $this->newFixture(new MemoryInputStream('"";Karlsruhe;76137'));
     $this->assertEquals(['', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function readQuotedValueWithQuotesInside() {
-    $in= $this->newReader('"Timm""Karlsruhe";76137');
+  public function read_quoted_value_with_quotes_inside() {
+    $in= $this->newFixture(new MemoryInputStream('"Timm""Karlsruhe";76137'));
     $this->assertEquals(['Timm"Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function quotesInsideUnquoted() {
-    $in= $this->newReader('He said "Hello";Karlsruhe;76137');
+  public function quotes_inside_unquoted() {
+    $in= $this->newFixture(new MemoryInputStream('He said "Hello";Karlsruhe;76137'));
     $this->assertEquals(['He said "Hello"', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function quoteInsideUnquoted() {
-    $in= $this->newReader('A single " is OK;Karlsruhe;76137');
+  public function quote_inside_unquoted() {
+    $in= $this->newFixture(new MemoryInputStream('A single " is OK;Karlsruhe;76137'));
     $this->assertEquals(['A single " is OK', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function multiLine() {
-    $in= $this->newReader(
-      "14:30-15:30;Development;'- Fix unittests\n- QA: Apidoc'",
+  public function multi_line() {
+    $in= $this->newFixture(
+      new MemoryInputStream("14:30-15:30;Development;'- Fix unittests\n- QA: Apidoc'"),
       (new CsvFormat())->withQuote("'")
     );
     $this->assertEquals(
@@ -214,9 +208,9 @@ class CsvListReaderTest extends TestCase {
   }
 
   #[Test]
-  public function multiLines() {
-    $in= $this->newReader(
-      "14:30-15:30;Development;'- Fix unittests\n- QA: Apidoc'\n15:30-15:49;Report;- Tests",
+  public function multi_lines() {
+    $in= $this->newFixture(
+      new MemoryInputStream("14:30-15:30;Development;'- Fix unittests\n- QA: Apidoc'\n15:30-15:49;Report;- Tests"),
       (new CsvFormat())->withQuote("'")
     );
     $this->assertEquals(['14:30-15:30', 'Development', "- Fix unittests\n- QA: Apidoc"], $in->read());
@@ -224,55 +218,55 @@ class CsvListReaderTest extends TestCase {
   }
 
   #[Test, Ignore('Is this really allowed?')]
-  public function partialQuoting() {
-    $in= $this->newReader('"Timm"|"Karlsruhe";76137');
+  public function partialquoting() {
+    $in= $this->newFixture(new MemoryInputStream('"Timm"|"Karlsruhe";76137'));
     $this->assertEquals(['Timm|Karlsruhe', '76131'], $in->read());
   }
 
   #[Test, Ignore('Is this really allowed?')]
-  public function partialQuotingDelimiter() {
-    $in= $this->newReader('Timm";"Karlsruhe;76137');
+  public function partial_quoting_delimiter() {
+    $in= $this->newFixture(new MemoryInputStream('Timm";"Karlsruhe;76137'));
     $this->assertEquals(['Timm;Karlsruhe', '76131'], $in->read());
   }
 
   #[Test, Expect(FormatException::class)]
-  public function unterminatedQuote() {
-    $this->newReader('"Unterminated;Karlsruhe;76131')->read();
+  public function unterminated_quote() {
+    $this->newFixture(new MemoryInputStream('"Unterminated;Karlsruhe;76131'))->read();
   }
 
   #[Test, Expect(FormatException::class)]
-  public function unterminatedQuoteInTheMiddle() {
-    $this->newReader('Timm;"Unterminated;76131')->read();
+  public function unterminated_quote_in_the_middle() {
+    $this->newFixture(new MemoryInputStream('Timm;"Unterminated;76131'))->read();
   }
 
   #[Test, Expect(FormatException::class)]
-  public function unterminatedQuoteRightBeforeSeparator() {
-    $this->newReader('";Karlsruhe;76131')->read();
+  public function unterminated_quote_right_before_separator() {
+    $this->newFixture(new MemoryInputStream('";Karlsruhe;76131'))->read();
   }
 
   #[Test, Expect(FormatException::class)]
-  public function unterminatedQuoteInTheMiddleRightBeforeSeparator() {
-    $this->newReader('Timm;";76131')->read();
+  public function unterminated_quote_in_the_middle_right_before_separator() {
+    $this->newFixture(new MemoryInputStream('Timm;";76131'))->read();
   }
 
   #[Test, Expect(FormatException::class)]
-  public function unterminatedQuoteAtEnd() {
-    $this->newReader('A;B;"')->read();
+  public function unterminated_quote_at_end() {
+    $this->newFixture(new MemoryInputStream('A;B;"'))->read();
   }
 
   #[Test, Expect(FormatException::class)]
-  public function unterminatedQuoteAtEndWithTrailingSeparator() {
-    $this->newReader('A;B;";')->read();
+  public function unterminated_quote_at_end_with_trailing_separator() {
+    $this->newFixture(new MemoryInputStream('A;B;";'))->read();
   }
 
   #[Test, Expect(FormatException::class)]
-  public function unterminatedQuoteAtBeginning() {
-    $this->newReader('"')->read();
+  public function unterminated_quote_at_beginning() {
+    $this->newFixture(new MemoryInputStream('"'))->read();
   }
 
   #[Test]
-  public function readingContinuesAfterBrokenLine() {
-    $in= $this->newReader('"Hello"-;Karlsruhe;76131'."\n".'Timm;Karlsruhe;76137');
+  public function reading_continues_after_broken_line() {
+    $in= $this->newFixture(new MemoryInputStream('"Hello"-;Karlsruhe;76131'."\n".'Timm;Karlsruhe;76137'));
     try {
       $in->read();
       $this->fail('Unterminated literal not detected', null, 'lang.FormatException');
@@ -281,53 +275,53 @@ class CsvListReaderTest extends TestCase {
   }
 
   #[Test]
-  public function readEmptyValue() {
-    $in= $this->newReader('Timm;;76137');
+  public function read_empty_value() {
+    $in= $this->newFixture(new MemoryInputStream('Timm;;76137'));
     $this->assertEquals(['Timm', '', '76137'], $in->read());
   }
 
   #[Test]
-  public function readEmptyValueAtBeginning() {
-    $in= $this->newReader(';Karlsruhe;76137');
+  public function read_empty_value_at_beginning() {
+    $in= $this->newFixture(new MemoryInputStream(';Karlsruhe;76137'));
     $this->assertEquals(['', 'Karlsruhe', '76137'], $in->read());
   }
 
   #[Test]
-  public function readEmptyValueAtEnd() {
-    $in= $this->newReader('Timm;Karlsruhe;');
+  public function read_empty_value_at_end() {
+    $in= $this->newFixture(new MemoryInputStream('Timm;Karlsruhe;'));
     $this->assertEquals(['Timm', 'Karlsruhe', ''], $in->read());
   }
 
   #[Test]
-  public function readEmptyValueAtEndWithTrailingDelimiter() {
-    $in= $this->newReader('Timm;Karlsruhe;;');
+  public function read_empty_value_at_end_with_trailing_delimiter() {
+    $in= $this->newFixture(new MemoryInputStream('Timm;Karlsruhe;;'));
     $this->assertEquals(['Timm', 'Karlsruhe', '', ''], $in->read());
   }
 
   #[Test, Expect(FormatException::class)]
-  public function illegalQuoting() {
-    $this->newReader('"Timm"Karlsruhe";76137')->read();
+  public function illegal_quoting() {
+    $this->newFixture(new MemoryInputStream('"Timm"Karlsruhe";76137'))->read();
   }
 
   #[Test]
-  public function tabDelimiter() {
-    $in= $this->newReader("A\tB\tC", CsvFormat::$TABS);
+  public function tab_delimiter() {
+    $in= $this->newFixture(new MemoryInputStream("A\tB\tC"), CsvFormat::$TABS);
     $this->assertEquals(['A', 'B', 'C'], $in->read());
   }
 
   #[Test]
-  public function spaceDelimiter() {
-    $in= $this->newReader('A B C', (new CsvFormat())->withDelimiter(' '));
+  public function space_delimiter() {
+    $in= $this->newFixture(new MemoryInputStream('A B C'), (new CsvFormat())->withDelimiter(' '));
     $this->assertEquals(['A', 'B', 'C'], $in->read());
   }
 
   #[Test]
-  public function wikipediaExample() {
-    $r= $this->newReader(
+  public function wikipedia_example() {
+    $r= $this->newFixture(new MemoryInputStream(
       '1997,Ford,E350,"ac, abs, moon",3000.00'."\n".
       '1999,Chevy,"Venture ""Extended Edition""","",4900.00'."\n".
       '1996,Jeep,Grand Cherokee,"MUST SELL!'."\n".
-      'air, moon roof, loaded",4799.00'."\n",
+      'air, moon roof, loaded",4799.00'."\n"),
       CsvFormat::$COMMAS
     );
     $this->assertEquals(['1997', 'Ford', 'E350', 'ac, abs, moon', '3000.00'], $r->read());

--- a/src/test/php/text/csv/unittest/CsvListWriterTest.class.php
+++ b/src/test/php/text/csv/unittest/CsvListWriterTest.class.php
@@ -4,113 +4,126 @@ use io\streams\{MemoryOutputStream, TextWriter};
 use lang\IllegalStateException;
 use text\csv\processors\FormatDate;
 use text\csv\{CsvFormat, CsvListWriter};
-use unittest\{Expect, Test, TestCase};
+use unittest\{Expect, Test};
 
-/**
- * TestCase
- *
- * @see      xp://text.csv.CsvListWriter
- */
-class CsvListWriterTest extends TestCase {
-  protected $out= null;
+class CsvListWriterTest extends CsvWriterTest {
 
   /**
-   * Creates a new list writer
+   * Creates a new CSV writer fixture
    *
-   * @param   text.csv.CsvFormat format
-   * @return  text.csv.CsvListWriter
+   * @param  io.streams.OutputStream $stream
+   * @param  text.csv.CsvFormat $format
+   * @return text.csv.CsvWriter
    */
-  protected function newWriter(CsvFormat $format= null) {
-    $this->out= new MemoryOutputStream();
-    return new CsvListWriter(new TextWriter($this->out), $format);
+  protected function newFixture($stream, $format= null) {
+    return new CsvListWriter(new TextWriter($stream), $format);
   }
 
   #[Test]
-  public function writeLine() {
-    $this->newWriter()->write(['Timm', 'Karlsruhe', '76137']);
-    $this->assertEquals("Timm;Karlsruhe;76137\n", $this->out->bytes());
+  public function write_line() {
+    $out= new MemoryOutputStream();
+    $this->newFixture($out)->write(['Timm', 'Karlsruhe', '76137']);
+
+    $this->assertEquals("Timm;Karlsruhe;76137\n", $out->bytes());
   }
 
   #[Test]
-  public function writeEmptyValue() {
-    $this->newWriter()->write(['Timm', '', '76137']);
-    $this->assertEquals("Timm;;76137\n", $this->out->bytes());
+  public function write_emptyValue() {
+    $out= new MemoryOutputStream();
+    $this->newFixture($out)->write(['Timm', '', '76137']);
+
+    $this->assertEquals("Timm;;76137\n", $out->bytes());
   }
 
   #[Test]
-  public function setHeaders() {
-    $writer= $this->newWriter();
+  public function set_headers() {
+    $out= new MemoryOutputStream();
+    $writer= $this->newFixture($out);
     $writer->setHeaders(['name', 'city', 'zip']);
     $writer->write(['Timm', 'Karlsruhe', '76137']);
-    $this->assertEquals("name;city;zip\nTimm;Karlsruhe;76137\n", $this->out->bytes());
+
+    $this->assertEquals("name;city;zip\nTimm;Karlsruhe;76137\n", $out->bytes());
   }
 
   #[Test, Expect(IllegalStateException::class)]
-  public function cannotSetHeadersAfterWriting() {
-    $writer= $this->newWriter();
+  public function cannot_set_headers_after_writing() {
+    $out= new MemoryOutputStream();
+    $writer= $this->newFixture($out);
     $writer->write(['Timm', 'Karlsruhe', '76137']);
     $writer->setHeaders(['name', 'city', 'zip']);
   }
 
   #[Test]
-  public function writeUnixMultiLineValue() {
-    $this->newWriter((new CsvFormat())->withQuote("'"))->write(['Timm', "76137\nKarlsruhe\nGermany"]);
-    $this->assertEquals("Timm;'76137\nKarlsruhe\nGermany'\n", $this->out->bytes());
+  public function write_unix_multi_line_value() {
+    $out= new MemoryOutputStream();
+    $this->newFixture($out, (new CsvFormat())->withQuote("'"))->write(['Timm', "76137\nKarlsruhe\nGermany"]);
+    $this->assertEquals("Timm;'76137\nKarlsruhe\nGermany'\n", $out->bytes());
   }
 
   #[Test]
-  public function writeMacMultiLineValue() {
-    $this->newWriter((new CsvFormat())->withQuote("'"))->write(['Timm', "76137\rKarlsruhe\rGermany"]);
-    $this->assertEquals("Timm;'76137\rKarlsruhe\rGermany'\n", $this->out->bytes());
+  public function write_mac_multi_line_value() {
+    $out= new MemoryOutputStream();
+    $this->newFixture($out, (new CsvFormat())->withQuote("'"))->write(['Timm', "76137\rKarlsruhe\rGermany"]);
+    $this->assertEquals("Timm;'76137\rKarlsruhe\rGermany'\n", $out->bytes());
   }
 
   #[Test]
-  public function writeWindowsMultiLineValue() {
-    $this->newWriter((new CsvFormat())->withQuote("'"))->write(['Timm', "76137\r\nKarlsruhe\r\nGermany"]);
-    $this->assertEquals("Timm;'76137\r\nKarlsruhe\r\nGermany'\n", $this->out->bytes());
+  public function write_windows_multiline_value() {
+    $out= new MemoryOutputStream();
+    $this->newFixture($out, (new CsvFormat())->withQuote("'"))->write(['Timm', "76137\r\nKarlsruhe\r\nGermany"]);
+    $this->assertEquals("Timm;'76137\r\nKarlsruhe\r\nGermany'\n", $out->bytes());
   }
 
   #[Test]
-  public function valueWithDelimiterIsQuoted() {
-    $this->newWriter((new CsvFormat())->withQuote("'"))->write(['Timm;Friebe', 'Karlsruhe', '76137']);
-    $this->assertEquals("'Timm;Friebe';Karlsruhe;76137\n", $this->out->bytes());
+  public function value_with_delimiter_is_quoted() {
+    $out= new MemoryOutputStream();
+    $this->newFixture($out, (new CsvFormat())->withQuote("'"))->write(['Timm;Friebe', 'Karlsruhe', '76137']);
+    $this->assertEquals("'Timm;Friebe';Karlsruhe;76137\n", $out->bytes());
   }
 
   #[Test]
-  public function delimiterIsQuoted() {
-    $this->newWriter((new CsvFormat())->withQuote("'"))->write([';', 'Karlsruhe', '76137']);
-    $this->assertEquals("';';Karlsruhe;76137\n", $this->out->bytes());
+  public function delimiter_is_quoted() {
+    $out= new MemoryOutputStream();
+    $this->newFixture($out, (new CsvFormat())->withQuote("'"))->write([';', 'Karlsruhe', '76137']);
+    $this->assertEquals("';';Karlsruhe;76137\n", $out->bytes());
   }
 
   #[Test]
-  public function quotesAroundValueAreEscaped() {
-    $this->newWriter((new CsvFormat())->withQuote("'"))->write(["'Hello'", 'Karlsruhe', '76137']);
-    $this->assertEquals("'''Hello''';Karlsruhe;76137\n", $this->out->bytes());
+  public function quotes_around_value_are_escaped() {
+    $out= new MemoryOutputStream();
+    $this->newFixture($out, (new CsvFormat())->withQuote("'"))->write(["'Hello'", 'Karlsruhe', '76137']);
+    $this->assertEquals("'''Hello''';Karlsruhe;76137\n", $out->bytes());
   }
 
   #[Test]
-  public function quotesInsideValueAreEscaped() {
-    $this->newWriter((new CsvFormat())->withQuote("'"))->write(["He said 'Hello' to me", 'Karlsruhe', '76137']);
-    $this->assertEquals("'He said ''Hello'' to me';Karlsruhe;76137\n", $this->out->bytes());
+  public function quotes_inside_value_are_escaped() {
+    $out= new MemoryOutputStream();
+    $this->newFixture($out, (new CsvFormat())->withQuote("'"))->write(["He said 'Hello' to me", 'Karlsruhe', '76137']);
+    $this->assertEquals("'He said ''Hello'' to me';Karlsruhe;76137\n", $out->bytes());
   }
 
   #[Test]
-  public function quotesAroundEmptyAreEscaped() {
-    $this->newWriter((new CsvFormat())->withQuote("'"))->write(["''", 'Karlsruhe', '76137']);
-    $this->assertEquals("'''''';Karlsruhe;76137\n", $this->out->bytes());
+  public function quotes_around_empty_are_escaped() {
+    $out= new MemoryOutputStream();
+    $this->newFixture($out, (new CsvFormat())->withQuote("'"))->write(["''", 'Karlsruhe', '76137']);
+    $this->assertEquals("'''''';Karlsruhe;76137\n", $out->bytes());
   }
 
   #[Test]
-  public function writeLineFromMap() {
-    $this->newWriter()->write(['name' => 'Timm', 'city' => 'Karlsruhe', 'zip' => '76137']);
-    $this->assertEquals("Timm;Karlsruhe;76137\n", $this->out->bytes());
+  public function write_line_from_map() {
+    $out= new MemoryOutputStream();
+    $this->newFixture($out)->write(['name' => 'Timm', 'city' => 'Karlsruhe', 'zip' => '76137']);
+
+    $this->assertEquals("Timm;Karlsruhe;76137\n", $out->bytes());
   }
 
   #[Test]
-  public function writeLineFromMapWithProcessor() {
-    $writer= $this->newWriter();
+  public function write_line_from_map_with_processor() {
+    $out= new MemoryOutputStream();
+    $writer= $this->newFixture($out);
     $writer->setProcessor(1, new FormatDate('d.m.Y'));
     $writer->write(['id' => 1, 'date' => new \util\Date('2012-02-10')]);
-    $this->assertEquals("1;10.02.2012\n", $this->out->bytes());
+
+    $this->assertEquals("1;10.02.2012\n", $out->bytes());
   }
 }

--- a/src/test/php/text/csv/unittest/CsvMapReaderTest.class.php
+++ b/src/test/php/text/csv/unittest/CsvMapReaderTest.class.php
@@ -4,45 +4,40 @@ use io\streams\{MemoryInputStream, TextReader};
 use text\csv\CsvMapReader;
 use unittest\{Test, TestCase, Values};
 
-/**
- * TestCase
- *
- * @see      xp://text.csv.CsvMapReader
- */
-class CsvMapReaderTest extends TestCase {
+class CsvMapReaderTest extends CsvReaderTest {
 
   /**
-   * Creates a new object reader
+   * Creates a new CSV reader fixture
    *
-   * @param   string $str
-   * @param   string[] $keys
-   * @return  text.csv.CsvMapReader
+   * @param  io.streams.InputStream $stream
+   * @param  text.csv.CsvFormat $format
+   * @return text.csv.CsvReader
    */
-  protected function newReader($str, array $keys= []) {
-    return new CsvMapReader(new TextReader(new MemoryInputStream($str)), $keys);
+  protected function newFixture($stream, $format= null) {
+    return new CsvMapReader(new TextReader($stream), [], $format);
   }
 
   #[Test]
-  public function setKeys() {
+  public function set_keys() {
     with ($keys= ['id', 'name', 'email']); {
-      $in= $this->newReader('');
+      $in= $this->newFixture(new MemoryInputStream(''));
       $in->setKeys($keys);
       $this->assertEquals($keys, $in->getKeys());
     }
   }
 
   #[Test]
-  public function withKeys() {
+  public function with_keys() {
     with ($keys= ['id', 'name', 'email']); {
-      $in= $this->newReader('');
+      $in= $this->newFixture(new MemoryInputStream(''));
       $this->assertEquals($in, $in->withKeys($keys));
       $this->assertEquals($keys, $in->getKeys());
     }
   }
 
   #[Test]
-  public function readRecord() {
-    $in= $this->newReader('1549;Timm;friebe@example.com', ['id', 'name', 'email']);
+  public function read_record() {
+    $in= $this->newFixture(new MemoryInputStream('1549;Timm;friebe@example.com'))->withKeys(['id', 'name', 'email']);
     $this->assertEquals(
       ['id' => '1549', 'name' => 'Timm', 'email' => 'friebe@example.com'],
       $in->read()
@@ -50,8 +45,8 @@ class CsvMapReaderTest extends TestCase {
   }
 
   #[Test]
-  public function readRecordWithHeaders() {
-    $in= $this->newReader("id;name;email\n1549;Timm;friebe@example.com");
+  public function read_record_with_headers() {
+    $in= $this->newFixture(new MemoryInputStream("id;name;email\n1549;Timm;friebe@example.com"));
     $in->setKeys($in->getHeaders());
     $this->assertEquals(
       ['id' => '1549', 'name' => 'Timm', 'email' => 'friebe@example.com'],
@@ -60,14 +55,14 @@ class CsvMapReaderTest extends TestCase {
   }
 
   #[Test, Values(["", "\n", "\n\n"])]
-  public function readEmpty($input) {
-    $in= $this->newReader($input, ['id', 'name', 'email']);
+  public function read_empty($input) {
+    $in= $this->newFixture(new MemoryInputStream($input))->withKeys(['id', 'name', 'email']);
     $this->assertNull($in->read());
   }
 
   #[Test]
-  public function readRecordWithExcess() {
-    $in= $this->newReader('1549;Timm;friebe@example.com;WILL_NOT_APPEAR', ['id', 'name', 'email']);
+  public function read_record_with_excess() {
+    $in= $this->newFixture(new MemoryInputStream('1549;Timm;friebe@example.com;WILL_NOT_APPEAR'))->withKeys(['id', 'name', 'email']);
     $this->assertEquals(
       ['id' => '1549', 'name' => 'Timm', 'email' => 'friebe@example.com'],
       $in->read()
@@ -75,8 +70,8 @@ class CsvMapReaderTest extends TestCase {
   }
 
   #[Test]
-  public function readRecordWithUnderrun() {
-    $in= $this->newReader('1549;Timm', ['id', 'name', 'email']);
+  public function read_record_with_underrun() {
+    $in= $this->newFixture(new MemoryInputStream('1549;Timm'))->withKeys(['id', 'name', 'email']);
     $this->assertEquals(
       ['id' => '1549', 'name' => 'Timm', 'email' => null],
       $in->read()
@@ -84,8 +79,8 @@ class CsvMapReaderTest extends TestCase {
   }
 
   #[Test]
-  public function readRecordAfterEmptyLine() {
-    $in= $this->newReader("\n1549;Timm", ['id', 'name']);
+  public function read_record_after_empty_line() {
+    $in= $this->newFixture(new MemoryInputStream("\n1549;Timm"))->withKeys(['id', 'name']);
     $this->assertEquals(
       ['id' => '1549', 'name' => 'Timm'],
       $in->read()
@@ -93,8 +88,8 @@ class CsvMapReaderTest extends TestCase {
   }
 
   #[Test]
-  public function readRecordsWithEmptyLineInBetween() {
-    $in= $this->newReader("1549;Timm\n1552;Alex", ['id', 'name']);
+  public function read_records_with_empty_line_in_between() {
+    $in= $this->newFixture(new MemoryInputStream("1549;Timm\n1552;Alex"))->withKeys(['id', 'name']);
     $this->assertEquals(
       [['id' => '1549', 'name' => 'Timm'], ['id' => '1552', 'name' => 'Alex']],
       [$in->read(), $in->read()]

--- a/src/test/php/text/csv/unittest/CsvMapWriterTest.class.php
+++ b/src/test/php/text/csv/unittest/CsvMapWriterTest.class.php
@@ -1,72 +1,78 @@
 <?php namespace text\csv\unittest;
 
-use io\streams\MemoryOutputStream;
-use text\csv\CsvMapWriter;
-use unittest\{Test, TestCase};
+use io\streams\{OutputStream, MemoryOutputStream, TextWriter};
+use text\csv\{CsvMapWriter, CsvFormat};
+use unittest\Test;
 
-/**
- * TestCase
- *
- * @see      xp://text.csv.CsvMapWriter
- */
-class CsvMapWriterTest extends TestCase {
-  protected $out= null;
+class CsvMapWriterTest extends CsvWriterTest {
 
   /**
-   * Creates a new Map writer
+   * Creates a new CSV writer fixture
    *
-   * @param   text.csv.CsvFormat format
-   * @return  text.csv.CsvMapWriter
+   * @param  io.streams.OutputStream $stream
+   * @param  text.csv.CsvFormat $format
+   * @return text.csv.CsvWriter
    */
-  protected function newWriter(\text\csv\CsvFormat $format= null) {
-    $this->out= new MemoryOutputStream();
-    return new CsvMapWriter(new \io\streams\TextWriter($this->out), $format);
+  protected function newFixture($stream, $format= null) {
+    return new CsvMapWriter(new TextWriter($stream), $format);
   }
 
   #[Test]
-  public function writeRecord() {
-    $this->newWriter()->write(['id' => 1549, 'name' => 'Timm', 'email' => 'friebe@example.com']);
-    $this->assertEquals("1549;Timm;friebe@example.com\n", $this->out->bytes());
+  public function write_record() {
+    $out= new MemoryOutputStream();
+    $this->newFixture($out)->write(['id' => 1549, 'name' => 'Timm', 'email' => 'friebe@example.com']);
+
+    $this->assertEquals("1549;Timm;friebe@example.com\n", $out->bytes());
   }
 
   #[Test]
-  public function writeRecordWithHeaders() {
-    $out= $this->newWriter();
-    $out->setHeaders(['id', 'name', 'email']);
-    $out->write(['id' => 1549, 'name' => 'Timm', 'email' => 'friebe@example.com']);
-    $this->assertEquals("id;name;email\n1549;Timm;friebe@example.com\n", $this->out->bytes());
+  public function write_record_with_headers() {
+    $out= new MemoryOutputStream();
+    $fixture= $this->newFixture($out);
+    $fixture->setHeaders(['id', 'name', 'email']);
+    $fixture->write(['id' => 1549, 'name' => 'Timm', 'email' => 'friebe@example.com']);
+
+    $this->assertEquals("id;name;email\n1549;Timm;friebe@example.com\n", $out->bytes());
   }
 
   #[Test]
-  public function writeUnorderedRecordWithHeaders() {
-    $out= $this->newWriter();
-    $out->setHeaders(['id', 'name', 'email']);
-    $out->write(['email' => 'friebe@example.com', 'name' => 'Timm', 'id' => 1549]);
-    $this->assertEquals("id;name;email\n1549;Timm;friebe@example.com\n", $this->out->bytes());
+  public function write_unordered_record_with_headers() {
+    $out= new MemoryOutputStream();
+    $fixture= $this->newFixture($out);
+    $fixture->setHeaders(['id', 'name', 'email']);
+    $fixture->write(['email' => 'friebe@example.com', 'name' => 'Timm', 'id' => 1549]);
+
+    $this->assertEquals("id;name;email\n1549;Timm;friebe@example.com\n", $out->bytes());
   }
 
 
   #[Test]
-  public function writeIncompleteRecordWithHeaders() {
-    $out= $this->newWriter();
-    $out->setHeaders(['id', 'name', 'email']);
-    $out->write(['id' => 1549, 'email' => 'friebe@example.com']);
-    $this->assertEquals("id;name;email\n1549;;friebe@example.com\n", $this->out->bytes());
+  public function write_incomplete_record_with_headers() {
+    $out= new MemoryOutputStream();
+    $fixture= $this->newFixture($out);
+    $fixture->setHeaders(['id', 'name', 'email']);
+    $fixture->write(['id' => 1549, 'email' => 'friebe@example.com']);
+
+    $this->assertEquals("id;name;email\n1549;;friebe@example.com\n", $out->bytes());
   }
 
   #[Test]
-  public function writeEmptyRecordWithHeaders() {
-    $out= $this->newWriter();
-    $out->setHeaders(['id', 'name', 'email']);
-    $out->write([]);
-    $this->assertEquals("id;name;email\n;;\n", $this->out->bytes());
+  public function write_empty_record_with_headers() {
+    $out= new MemoryOutputStream();
+    $fixture= $this->newFixture($out);
+    $fixture->setHeaders(['id', 'name', 'email']);
+    $fixture->write([]);
+
+    $this->assertEquals("id;name;email\n;;\n", $out->bytes());
   }
 
   #[Test]
-  public function writeRecordWithExtraDataWithHeaders() {
-    $out= $this->newWriter();
-    $out->setHeaders(['id', 'name', 'email']);
-    $out->write(['id' => 1549, 'name' => 'Timm', 'email' => 'friebe@example.com', 'extra' => 'WILL_NOT_APPEAR']);
-    $this->assertEquals("id;name;email\n1549;Timm;friebe@example.com\n", $this->out->bytes());
+  public function write_record_with_extra_data_with_headers() {
+    $out= new MemoryOutputStream();
+    $fixture= $this->newFixture($out);
+    $fixture->setHeaders(['id', 'name', 'email']);
+    $fixture->write(['id' => 1549, 'name' => 'Timm', 'email' => 'friebe@example.com', 'extra' => 'WILL_NOT_APPEAR']);
+
+    $this->assertEquals("id;name;email\n1549;Timm;friebe@example.com\n", $out->bytes());
   }
 }

--- a/src/test/php/text/csv/unittest/CsvObjectReaderTest.class.php
+++ b/src/test/php/text/csv/unittest/CsvObjectReaderTest.class.php
@@ -1,39 +1,26 @@
 <?php namespace text\csv\unittest;
 
-use io\streams\MemoryInputStream;
+use io\streams\{MemoryInputStream, TextReader};
 use text\csv\CsvObjectReader;
-use unittest\{Test, TestCase};
+use unittest\Test;
+use lang\XPClass;
 
-/**
- * TestCase
- *
- * @see      xp://text.csv.CsvObjectReader
- */
-class CsvObjectReaderTest extends TestCase {
+class CsvObjectReaderTest extends CsvReaderTest {
 
   /**
-   * Creates a new object reader
+   * Creates a new CSV reader fixture
    *
-   * @param   string str
-   * @param   lang.XPClass class
-   * @return  text.csv.CsvObjectReader
+   * @param  io.streams.InputStream $stream
+   * @param  text.csv.CsvFormat $format
+   * @return text.csv.CsvReader
    */
-  protected function newReader($str, \lang\XPClass $class) {
-    return new CsvObjectReader(new \io\streams\TextReader(new MemoryInputStream($str)), $class);
+  protected function newFixture($stream, $format= null) {
+    return new CsvObjectReader(new TextReader($stream), new XPClass(Person::class), $format);
   }
 
   #[Test]
-  public function readAddress() {
-    $in= $this->newReader('Timm;Karlsruhe;76137', \lang\XPClass::forName('text.csv.unittest.Address'));
-    $this->assertEquals(
-      new Address('Timm', 'Karlsruhe', '76137'), 
-      $in->read(['name', 'city', 'zip'])
-    );
-  }
-
-  #[Test]
-  public function readPerson() {
-    $in= $this->newReader('1549;Timm;friebe@example.com', \lang\XPClass::forName('text.csv.unittest.Person'));
+  public function read_person() {
+    $in= $this->newFixture(new MemoryInputStream('1549;Timm;friebe@example.com'));
     $this->assertEquals(
       new Person('1549', 'Timm', 'friebe@example.com'), 
       $in->read(['id', 'name', 'email'])
@@ -41,8 +28,8 @@ class CsvObjectReaderTest extends TestCase {
   }
 
   #[Test]
-  public function readPersonReSorted() {
-    $in= $this->newReader('friebe@example.com;1549;Timm', \lang\XPClass::forName('text.csv.unittest.Person'));
+  public function read_person_resorted() {
+    $in= $this->newFixture(new MemoryInputStream('friebe@example.com;1549;Timm'));
     $this->assertEquals(
       new Person('1549', 'Timm', 'friebe@example.com'), 
       $in->read(['email', 'id', 'name'])
@@ -50,8 +37,8 @@ class CsvObjectReaderTest extends TestCase {
   }
 
   #[Test]
-  public function readPersonCompletely() {
-    $in= $this->newReader('1549;Timm;friebe@example.com', \lang\XPClass::forName('text.csv.unittest.Person'));
+  public function read_person_completely() {
+    $in= $this->newFixture(new MemoryInputStream('1549;Timm;friebe@example.com'));
     $this->assertEquals(
       new Person('1549', 'Timm', 'friebe@example.com'), 
       $in->read()
@@ -59,8 +46,8 @@ class CsvObjectReaderTest extends TestCase {
   }
 
   #[Test]
-  public function readPersonPartially() {
-    $in= $this->newReader('1549;Timm;friebe@example.com', \lang\XPClass::forName('text.csv.unittest.Person'));
+  public function read_person_partially() {
+    $in= $this->newFixture(new MemoryInputStream('1549;Timm;friebe@example.com'));
     $this->assertEquals(
       new Person('1549', 'Timm', ''), 
       $in->read(['id', 'name'])
@@ -68,8 +55,8 @@ class CsvObjectReaderTest extends TestCase {
   }
 
   #[Test]
-  public function readEmpty() {
-    $in= $this->newReader('', \lang\XPClass::forName('text.csv.unittest.Address'));
-    $this->assertNull($in->read(['name', 'city', 'zip']));
+  public function read_empty() {
+    $in= $this->newFixture(new MemoryInputStream(''));
+    $this->assertNull($in->read(['id', 'name', 'email']));
   }
 }

--- a/src/test/php/text/csv/unittest/CsvObjectWriterTest.class.php
+++ b/src/test/php/text/csv/unittest/CsvObjectWriterTest.class.php
@@ -2,54 +2,58 @@
 
 use io\streams\{MemoryOutputStream, TextWriter};
 use text\csv\{CsvFormat, CsvObjectWriter};
-use unittest\{Test, TestCase};
+use unittest\Test;
 
-/**
- * TestCase
- *
- * @see      xp://text.csv.CsvObjectWriter
- */
-class CsvObjectWriterTest extends TestCase {
-  protected $out= null;
+class CsvObjectWriterTest extends CsvWriterTest {
 
   /**
-   * Creates a new object writer
+   * Creates a new CSV writer fixture
    *
-   * @param   text.csv.CsvFormat format
-   * @return  text.csv.CsvObjectWriter
+   * @param  io.streams.OutputStream $stream
+   * @param  text.csv.CsvFormat $format
+   * @return text.csv.CsvWriter
    */
-  protected function newWriter(CsvFormat $format= null) {
-    $this->out= new MemoryOutputStream();
-    return new CsvObjectWriter(new TextWriter($this->out), $format);
+  protected function newFixture($stream, $format= null) {
+    return new CsvObjectWriter(new TextWriter($stream), $format);
   }
 
   #[Test]
   public function writePerson() {
-    $this->newWriter()->write(new Person(1549, 'Timm', 'friebe@example.com'));
-    $this->assertEquals("1549;Timm;friebe@example.com\n", $this->out->bytes());
+    $out= new MemoryOutputStream();
+    $this->newFixture($out)->write(new Person(1549, 'Timm', 'friebe@example.com'));
+
+    $this->assertEquals("1549;Timm;friebe@example.com\n", $out->bytes());
   }
 
   #[Test]
   public function writePersonReSorted() {
-    $this->newWriter()->write(new Person(1549, 'Timm', 'friebe@example.com'), ['email', 'id', 'name']);
-    $this->assertEquals("friebe@example.com;1549;Timm\n", $this->out->bytes());
+    $out= new MemoryOutputStream();
+    $this->newFixture($out)->write(new Person(1549, 'Timm', 'friebe@example.com'), ['email', 'id', 'name']);
+
+    $this->assertEquals("friebe@example.com;1549;Timm\n", $out->bytes());
   }
 
   #[Test]
   public function writePersonPartially() {
-    $this->newWriter()->write(new Person(1549, 'Timm', 'friebe@example.com'), ['id', 'name']);
-    $this->assertEquals("1549;Timm\n", $this->out->bytes());
+    $out= new MemoryOutputStream();
+    $this->newFixture($out)->write(new Person(1549, 'Timm', 'friebe@example.com'), ['id', 'name']);
+
+    $this->assertEquals("1549;Timm\n", $out->bytes());
   }
 
   #[Test]
   public function writeAddress() {
-    $this->newWriter()->write(new Address('Timm', 'Karlsruhe', '76137'));
-    $this->assertEquals("Timm;Karlsruhe;76137\n", $this->out->bytes());
+    $out= new MemoryOutputStream();
+    $this->newFixture($out)->write(new Address('Timm', 'Karlsruhe', '76137'));
+
+    $this->assertEquals("Timm;Karlsruhe;76137\n", $out->bytes());
   }
 
   #[Test]
   public function writeAddressPartially() {
-    $this->newWriter()->write(new Address('Timm', 'Karlsruhe', '76137'), ['city', 'zip']);
-    $this->assertEquals("Karlsruhe;76137\n", $this->out->bytes());
+    $out= new MemoryOutputStream();
+    $this->newFixture($out)->write(new Address('Timm', 'Karlsruhe', '76137'), ['city', 'zip']);
+
+    $this->assertEquals("Karlsruhe;76137\n", $out->bytes());
   }
 }

--- a/src/test/php/text/csv/unittest/CsvReaderTest.class.php
+++ b/src/test/php/text/csv/unittest/CsvReaderTest.class.php
@@ -1,0 +1,34 @@
+<?php namespace text\csv\unittest;
+
+use io\streams\{InputStream, MemoryInputStream};
+use unittest\{Test, TestCase};
+
+abstract class CsvReaderTest extends TestCase {
+
+  /**
+   * Creates a new CSV reader fixture
+   *
+   * @param  io.streams.InputStream $stream
+   * @param  text.csv.CsvFormat $format
+   * @return text.csv.CsvReader
+   */
+  protected abstract function newFixture($stream, $format= null);
+
+  #[Test]
+  public function can_create() {
+    $this->newFixture(new MemoryInputStream(''));
+  }
+
+  #[Test]
+  public function can_close() {
+    $in= new class() implements InputStream {
+      public $closed= false;
+      public function available() { return 0; }
+      public function read($length= 8192) { /** NOOP */ }
+      public function close() { $this->closed= true; }
+    };
+    $this->newFixture($in)->close();
+
+    $this->assertTrue($in->closed);
+  }
+}

--- a/src/test/php/text/csv/unittest/CsvWriterTest.class.php
+++ b/src/test/php/text/csv/unittest/CsvWriterTest.class.php
@@ -1,0 +1,34 @@
+<?php namespace text\csv\unittest;
+
+use io\streams\{OutputStream, MemoryOutputStream};
+use unittest\{Test, TestCase};
+
+abstract class CsvWriterTest extends TestCase {
+
+  /**
+   * Creates a new CSV writer fixture
+   *
+   * @param  io.streams.OutputStream $stream
+   * @param  text.csv.CsvFormat $format
+   * @return text.csv.CsvWriter
+   */
+  protected abstract function newFixture($stream, $format= null);
+
+  #[Test]
+  public function can_create() {
+    $this->newFixture(new MemoryOutputStream());
+  }
+
+  #[Test]
+  public function can_close() {
+    $out= new class() implements OutputStream {
+      public $closed= false;
+      public function write($bytes) { /** NOOP */ }
+      public function flush() { /** NOOP */ }
+      public function close() { $this->closed= true; }
+    };
+    $this->newFixture($out)->close();
+
+    $this->assertTrue($out->closed);
+  }
+}


### PR DESCRIPTION
This makes the CsvReader and CsvWriter base classes implement the `lang.Closeable` interface, which, when called will close the underlying stream.

See also #2 